### PR TITLE
fix: error when first key was used

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -139,7 +139,7 @@ local generate_key = function(bookmarks)
   end)
   local idx = 1
   for _, key in ipairs(keys) do
-    if key2rank[key] < key2rank[mb[idx]] then
+    if idx > #mb or key2rank[key] < key2rank[mb[idx]] then
       return key
     end
     idx = idx + 1


### PR DESCRIPTION
I can not create new mark when key '0' was used.