### PR TITLE
fix: generate_key() crashes when a bookmark uses a key outside the pool

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -128,7 +128,7 @@ local generate_key = function(bookmarks)
 	local key2rank = get_state_attr("key2rank")
 	local mb = {}
 	for _, item in pairs(bookmarks) do
-		if #item.key == 1 then
+		if #item.key == 1 and key2rank[item.key] then
 			table.insert(mb, item.key)
 		end
 	end


### PR DESCRIPTION
## Summary

`generate_key()` (used by `save` to suggest the next free key for a new bookmark) crashes with `attempt to compare nil with number` if any existing bookmark's key isn't a member of the configured key pool.

`save` itself doesn't restrict the key you type to the configured pool (any single character is accepted), so it's easy to end up with a bookmark like `key = "."` that isn't in the default `0-9a-zA-Z` pool. The next time you try to bookmark a *different* new path with `save`, `generate_key()` collects all existing keys into `mb`, then sorts with:

```lua
table.sort(mb, function(a, b)
  return key2rank[a] < key2rank[b]
end)
```

`key2rank["."]` is `nil`, so `nil < number` raises a Lua error — before the key-input prompt ever renders. In practice: type a tag, hit enter, and the plugin just dies with no key prompt.

#16 (741c05a) partially addressed this by registering keys from `options.bookmarks` (config-provided bookmarks) into `key2rank` during `setup()`. That covers bookmarks declared in `init.lua`, but not ones added later through the interactive `save` prompt with a custom key — those still crash `generate_key()` on the next `save` of an unrelated path.

## Fix

Filter `generate_key()`'s candidate list to keys already known to `key2rank`, regardless of how they got into `bookmarks` (config-declared, loaded from the persisted file, or saved interactively):

```lua
if #item.key == 1 and key2rank[item.key] then
```

## Test plan

- [x] Reproduced the crash in a standalone Lua repro mirroring `generate_key()`, seeded with a bookmark using an out-of-pool key (`.`) — confirmed `attempt to compare nil with number`.
- [x] Applied the fix and reran the repro — `generate_key()` now returns a valid next key without error.
- [x] `luac -p main.lua` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)